### PR TITLE
Reservation list endpoint

### DIFF
--- a/app/controllers/v1/reservations_controller.rb
+++ b/app/controllers/v1/reservations_controller.rb
@@ -19,6 +19,18 @@ module Controllers
             end
           end
         end
+
+        params do
+          optional :start_date, type: Date
+          optional :finish_date, type: Date
+        end
+        get do
+          result = ListReservations.call(params: declared(params))
+          return result.reservations if result.success?
+
+          status(400)
+          { error: result.error }
+        end
       end
     end
   end

--- a/app/interactors/list_reservations.rb
+++ b/app/interactors/list_reservations.rb
@@ -1,0 +1,31 @@
+# Lists reservations, if no date range is provided returns all the reservations
+class ListReservations
+  include Interactor
+
+  delegate :params, to: :context
+
+  def call
+    context.reservations = if params[:start_date].present? && params[:finish_date].present?
+                             reservations_in_range
+                           else
+                             unfiltered_reservations
+                           end
+  end
+
+  private
+
+  def unfiltered_reservations
+    Reservation.all.map { |reservation| ReservationSerializer.serialize_reservation reservation }
+  end
+
+  def reservations_in_range
+    Reservation.association_join(:presentation) # Solves N+1 Query
+               .all
+               .select { |r| date_in_range?(r.presentation.date) }
+               .map { |reservation| ReservationSerializer.serialize_reservation reservation }
+  end
+
+  def date_in_range?(date)
+    date >= params[:start_date] && date <= params[:finish_date]
+  end
+end

--- a/spec/controllers/v1/movies_controller_spec.rb
+++ b/spec/controllers/v1/movies_controller_spec.rb
@@ -56,7 +56,7 @@ describe Controllers::V1::MoviesController do
       end
     end
 
-    context 'when search success' do
+    context 'when search succeeds' do
       let(:create_movie) do
         params = JSON.parse(MoviesStubs.movie_creation_json).deep_symbolize_keys
         CreateMovie.call(params: params)

--- a/spec/controllers/v1/reservations_controller_spec.rb
+++ b/spec/controllers/v1/reservations_controller_spec.rb
@@ -44,4 +44,64 @@ describe Controllers::V1::ReservationsController do
       end
     end
   end
+
+  context 'GET /api/v1/reservations' do
+    subject(:request) do
+      get(
+        "/api/v1/reservations/?start_date=#{start_date}&finish_date=#{finish_date}",
+        'CONTENT_TYPE' => 'application/json'
+      )
+    end
+
+    context 'when search fails' do
+      before { request }
+
+      let(:start_date) { 'blablabla' }
+      let(:finish_date) { 'blablabla' }
+
+      it 'responds with 400 status' do
+        expect(last_response.status).to eq 400
+      end
+
+      it 'responds with the validation errors' do
+        expect(JSON.parse(last_response.body)['error'].present?).to be_truthy
+      end
+    end
+
+    context 'when search succeeds' do
+      let(:request) do
+        get(
+          '/api/v1/reservations',
+          'CONTENT_TYPE' => 'application/json'
+        )
+      end
+
+      let(:movie) do
+        movie_params = JSON.parse(MoviesStubs.movie_creation_json).deep_symbolize_keys
+        CreateMovie.call(params: movie_params).movie
+      end
+
+      let(:reservation) do
+        reservation_params = { movie_id: movie[:id], date: movie[:presentations].first[:date] }
+        CreateReservation.call(params: reservation_params).reservation
+        Reservation.first
+      end
+
+      before do
+        reservation
+        request
+      end
+
+      it 'responds with 200 status' do
+        expect(last_response.status).to eq 200
+      end
+
+      it 'responds with the serialized reservations' do
+        expected_response = ReservationSerializer.serialize_reservation(reservation)
+                                                 .deep_stringify_keys
+        expected_response['presentation']['date'] = expected_response['presentation']['date'].to_s
+        expect(JSON.parse(last_response.body)).to eq([expected_response])
+      end
+    end
+  end
 end

--- a/spec/interactors/create_reservation_spec.rb
+++ b/spec/interactors/create_reservation_spec.rb
@@ -2,7 +2,7 @@ describe CreateReservation do
   describe '#call' do
     subject(:create_reservation) { described_class.call(params: params) }
 
-    let(:params) do 
+    let(:params) do
       { movie_id: Movie.first.id, date: Movie.first.presentations.first.date }
     end
 
@@ -11,14 +11,12 @@ describe CreateReservation do
       CreateMovie.call(params: params)
     end
 
-    before do
-      create_movie
-    end
+    before { create_movie }
 
     context 'when the presentation exists and has available places' do
       it "saves the reservation record with it's presentation reference" do
         create_reservation
-        expect(Presentation.all.map { |p| p.id })
+        expect(Presentation.all.map(&:id))
           .to include(Reservation.first.presentation_id)
       end
 
@@ -34,9 +32,7 @@ describe CreateReservation do
     end
 
     context 'when reservation fails' do
-      before do
-        create_reservation
-      end
+      before { create_reservation }
 
       context 'when provided movie id is not found' do
         let(:params) { { movie_id: -1 } }

--- a/spec/interactors/list_reservations_spec.rb
+++ b/spec/interactors/list_reservations_spec.rb
@@ -1,0 +1,62 @@
+describe ListReservations do
+  describe '#call' do
+    subject(:list_reservations) { described_class.call(params: params) }
+
+    let(:params) do
+      { start_date: '2030-01-01'.to_date, finish_date: '2010-01-01'.to_date }
+    end
+
+    let(:movie) do
+      movie_params = JSON.parse(MoviesStubs.movie_creation_json).deep_symbolize_keys
+      CreateMovie.call(params: movie_params).movie
+    end
+
+    before do
+      reservation_params = { movie_id: movie[:id], date: movie[:presentations].first[:date] }
+      CreateReservation.call(params: reservation_params)
+    end
+
+    context 'when records are not found' do
+      it 'returns an empty array' do
+        expect(list_reservations.reservations).to be_empty
+      end
+
+      it 'the context succeeds' do
+        expect(list_reservations).to be_a_success
+      end
+    end
+
+    context 'when no date range params are provided' do
+      let(:params) { {} }
+
+      it 'lists all movie records' do
+        expect(list_reservations.reservations.size).to eq(Reservation.count)
+      end
+
+      it 'the context succeeds' do
+        expect(list_reservations).to be_a_success
+      end
+    end
+
+    context 'when records are within the dare range' do
+      before do
+        reservation_params = { movie_id: movie[:id], date: movie[:presentations][1][:date] }
+        CreateReservation.call(params: reservation_params)
+      end
+
+      let(:date) { movie[:presentations][1][:date] }
+
+      let(:params) do
+        { start_date: date, finish_date: date }
+      end
+
+      it 'returns the records within the range' do
+        expect(list_reservations.reservations.count).to eq(1)
+      end
+
+      it 'the context succeeds' do
+        expect(list_reservations).to be_a_success
+      end
+    end
+  end
+end

--- a/spec/stubs/movies_stubs.rb
+++ b/spec/stubs/movies_stubs.rb
@@ -8,10 +8,10 @@ class MoviesStubs
         image_url: 'https://starwars.com',
         presentations: [
           {
-            date: '2020-03-02'
+            date: '2019-01-01'
           },
           {
-            date: '2020-04-02'
+            date: '2020-01-01'
           }
         ]
       }.to_json


### PR DESCRIPTION
Details:
  - if both start_day and finish_date are not provided as query params, all the reservation records are returned
  - if both start_day and finish_date are provided as query params, the records within that date range (inclusive) are returned